### PR TITLE
"fixed the exemple of README.md"

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,7 @@ import json # for json dump only
 file_path = os.path.join('.', 'tests', 'code_postaux_v201410.csv')
 
 # Open your file and run csv_detective
-with open(file_path, 'r') as file:
-	inspection_results = routine(file)
+inspection_results = routine(file_path)
 
 # Write your file as json
 with open(file_path.replace('.csv', '.json'), 'wb') as fp:


### PR DESCRIPTION
In the example of the README.md, we obtain this error:
TypeError: Expected object of type bytes or bytearray, got: <class 'str'>
because the routine function expected an object of type bytes or bytearray and got an object of type"_io.TextIOWrapper".

So, I modified : "with open(file_path, 'r') as file:
	inspection_results = routine(file)"
to:
"inspection_results = routine(file_path)"
