### PR TITLE
Improving continuous column detection

### DIFF
--- a/csv_detective/detection.py
+++ b/csv_detective/detection.py
@@ -9,22 +9,38 @@ def detect_ints_as_floats(table):
     return res.index[res]
 
 
-def detect_continuous_variable(table):
+def detect_continuous_variable(table, continuous_th=0.9):
     """
-    Detects whether a column contains continuous variables. We consider a continuous variable a float value.
+    Detects whether a column contains continuous variables. We consider a continuous column a columnb taht contains
+    a considerable amount of float values.
     We removed the integers as we then end up with postal codes, insee codes, and all sort of codes and types.
     This is not optimal but it will do for now.
     :param table:
     :return:
     """
+
+    def check_threshold(serie, continuous_th):
+        count = serie.value_counts().to_dict()
+        total_nb = len(serie)
+        nb_floats = count[float]
+        nb_ints = count[int]
+        nb_other = count[False]
+        if nb_floats / total_nb >= continuous_th:
+            return True
+        else:
+            return False
+
+
     def parses_to_integer(value):
         try:
             value = value.replace(',', '.')
             value = literal_eval(value)
-            return isinstance(value, float)
+            return type(value)
+
+            # return isinstance(value, float)
         except:
             return False
-    res = table.apply(lambda serie: all(serie.apply(parses_to_integer)))
+    res = table.apply(lambda serie: check_threshold(serie.apply(parses_to_integer), continuous_th))
     return res.index[res]
 
 

--- a/csv_detective/detection.py
+++ b/csv_detective/detection.py
@@ -11,7 +11,7 @@ def detect_ints_as_floats(table):
 
 def detect_continuous_variable(table, continuous_th=0.9):
     """
-    Detects whether a column contains continuous variables. We consider a continuous column a columnb taht contains
+    Detects whether a column contains continuous variables. We consider a continuous column one that contains
     a considerable amount of float values.
     We removed the integers as we then end up with postal codes, insee codes, and all sort of codes and types.
     This is not optimal but it will do for now.
@@ -22,9 +22,10 @@ def detect_continuous_variable(table, continuous_th=0.9):
     def check_threshold(serie, continuous_th):
         count = serie.value_counts().to_dict()
         total_nb = len(serie)
-        nb_floats = count[float]
-        nb_ints = count[int]
-        nb_other = count[False]
+        if float in count:
+            nb_floats = count[float]
+        else:
+            return False
         if nb_floats / total_nb >= continuous_th:
             return True
         else:
@@ -37,7 +38,6 @@ def detect_continuous_variable(table, continuous_th=0.9):
             value = literal_eval(value)
             return type(value)
 
-            # return isinstance(value, float)
         except:
             return False
     res = table.apply(lambda serie: check_threshold(serie.apply(parses_to_integer), continuous_th))

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -28,19 +28,19 @@ def test_detetect_categorical_variable():
 # continous
 def test_detect_continous_variable():
     continous_col = random.random(100)
-    continous_col_2 = [1, 1.0, 2.0, 3., 4.0, 5.0, 6.0, 7, 21]
+    continous_col_2 = [1., 1.0, 2.0, 3., 4.0, 5.0, 6.0, 7, 21, 3] * 10
     not_continous_col = ["type_a"] * 33 + ["type_b"] * 33 + ["type_c"] * 34
 
     df_dict = {"cont": continous_col, "not_cont": not_continous_col}
     df_dict_2 = {"cont": continous_col_2, "not_cont": not_continous_col}
 
     df = pd.DataFrame(df_dict, dtype="unicode")
-    df = pd.DataFrame(df_dict_2, dtype="unicode")
+    df2 = pd.DataFrame(df_dict_2, dtype="unicode")
 
     res = detect_continuous_variable(df)
+    res2 = detect_continuous_variable(df2, continuous_th=.65)
     assert res.values and res.values[0] == "cont"
-
-
+    assert res2.values and res2.values[0] == "cont"
 
 # csp_insee
 def test_match_csp_insee():

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -28,10 +28,14 @@ def test_detetect_categorical_variable():
 # continous
 def test_detect_continous_variable():
     continous_col = random.random(100)
+    continous_col_2 = [1, 1.0, 2.0, 3., 4.0, 5.0, 6.0, 7, 21]
     not_continous_col = ["type_a"] * 33 + ["type_b"] * 33 + ["type_c"] * 34
 
     df_dict = {"cont": continous_col, "not_cont": not_continous_col}
+    df_dict_2 = {"cont": continous_col_2, "not_cont": not_continous_col}
+
     df = pd.DataFrame(df_dict, dtype="unicode")
+    df = pd.DataFrame(df_dict_2, dtype="unicode")
 
     res = detect_continuous_variable(df)
     assert res.values and res.values[0] == "cont"


### PR DESCRIPTION
We were allowing only floats as continuous, now we accept a threshold of floats, i.e., not all the columns has to contain floats to be accepted. It may contain integers. 